### PR TITLE
Add livekit call service

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/Session.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/Session.kt
@@ -36,6 +36,7 @@ import org.matrix.android.sdk.api.session.file.FileService
 import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilitiesService
 import org.matrix.android.sdk.api.session.identity.IdentityService
 import org.matrix.android.sdk.api.session.integrationmanager.IntegrationManagerService
+import org.matrix.android.sdk.api.session.livekitcall.LivekitCallSignalingService
 import org.matrix.android.sdk.api.session.media.MediaService
 import org.matrix.android.sdk.api.session.openid.OpenIdService
 import org.matrix.android.sdk.api.session.permalinks.PermalinkService
@@ -232,6 +233,8 @@ interface Session {
      * Returns the call signaling service associated with the session.
      */
     fun callSignalingService(): CallSignalingService
+
+    fun livekitCallSignalingService(): LivekitCallSignalingService
 
     /**
      * Returns the file download service associated with the session.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/EventType.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/events/model/EventType.kt
@@ -84,6 +84,19 @@ object EventType {
     const val CALL_NEGOTIATE = "m.call.negotiate"
     const val CALL_REJECT = "m.call.reject"
     const val CALL_HANGUP = "m.call.hangup"
+
+    // Livekit Call Events
+    const val GK_CALL_INVITE = "gk.call.invite"
+    const val GK_CALL_ANSWER = "gk.call.answer"
+    const val GK_CALL_SELECT_ANSWER = "gk.call.select_answer"
+    const val GK_CALL_REJECT = "gk.call.reject"
+    const val GK_CALL_HANGUP = "gk.call.hangup"
+
+    val callInvite = listOf(CALL_INVITE, GK_CALL_INVITE)
+    val callAnswer = listOf(CALL_ANSWER, GK_CALL_ANSWER)
+    val callReject = listOf(CALL_REJECT, GK_CALL_REJECT)
+    val callHangUp = listOf(CALL_HANGUP, GK_CALL_HANGUP)
+
     val CALL_ASSERTED_IDENTITY = StableUnstableId(stable = "m.call.asserted_identity", unstable = "org.matrix.call.asserted_identity")
 
     // This type is not processed by the client, just sent to the server
@@ -126,6 +139,14 @@ object EventType {
                 type == CALL_NEGOTIATE ||
                 type == CALL_REJECT ||
                 type == CALL_REPLACES
+    }
+
+    fun isLivekitCallEvent(type: String): Boolean {
+        return type == GK_CALL_INVITE ||
+                type == GK_CALL_ANSWER ||
+                type == GK_CALL_HANGUP ||
+                type == GK_CALL_SELECT_ANSWER ||
+                type == GK_CALL_REJECT
     }
 
     fun isVerificationEvent(type: String): Boolean {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/livekitcall/LivekitCallListener.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/livekitcall/LivekitCallListener.kt
@@ -1,0 +1,51 @@
+package org.matrix.android.sdk.api.session.livekitcall
+
+import org.matrix.android.sdk.api.session.room.model.call.CallAnswerContent
+import org.matrix.android.sdk.api.session.room.model.call.CallAssertedIdentityContent
+import org.matrix.android.sdk.api.session.room.model.call.CallHangupContent
+import org.matrix.android.sdk.api.session.room.model.call.CallNegotiateContent
+import org.matrix.android.sdk.api.session.room.model.call.CallRejectContent
+import org.matrix.android.sdk.api.session.room.model.call.CallSelectAnswerContent
+import org.matrix.android.sdk.api.session.room.model.livekitcall.LivekitCallInviteContent
+
+interface LivekitCallListener {
+    /**
+     * Called when there is an incoming call within the room.
+     */
+    fun onCallInviteReceived(mxCall: MxLivekitCall, callInviteContent: LivekitCallInviteContent)
+
+    /**
+     * An outgoing call is started.
+     */
+    fun onCallAnswerReceived(callAnswerContent: CallAnswerContent)
+
+    /**
+     * Called when a called has been hung up.
+     */
+    fun onCallHangupReceived(callHangupContent: CallHangupContent)
+
+    /**
+     * Called when a called has been rejected.
+     */
+    fun onCallRejectReceived(callRejectContent: CallRejectContent)
+
+    /**
+     * Called when an answer has been selected.
+     */
+    fun onCallSelectAnswerReceived(callSelectAnswerContent: CallSelectAnswerContent)
+
+    /**
+     * Called when a negotiation is sent.
+     */
+    fun onCallNegotiateReceived(callNegotiateContent: CallNegotiateContent)
+
+    /**
+     * Called when the call has been managed by an other session.
+     */
+    fun onCallManagedByOtherSession(callId: String)
+
+    /**
+     * Called when an asserted identity event is received.
+     */
+    fun onCallAssertedIdentityReceived(callAssertedIdentityContent: CallAssertedIdentityContent)
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/livekitcall/LivekitCallSignalingService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/livekitcall/LivekitCallSignalingService.kt
@@ -1,0 +1,17 @@
+package org.matrix.android.sdk.api.session.livekitcall
+
+interface LivekitCallSignalingService {
+
+    /**
+     * Create an outgoing call.
+     */
+    fun createOutgoingCall(roomId: String, otherUserId: String, isVideoCall: Boolean): MxLivekitCall
+
+    fun addCallListener(listener: LivekitCallListener)
+
+    fun removeCallListener(listener: LivekitCallListener)
+
+    fun getCallWithId(callId: String): MxLivekitCall?
+
+    fun isThereAnyActiveCall(): Boolean
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/livekitcall/LivekitCallState.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/livekitcall/LivekitCallState.kt
@@ -1,0 +1,31 @@
+package org.matrix.android.sdk.api.session.livekitcall
+
+import org.matrix.android.sdk.api.session.room.model.call.EndCallReason
+
+sealed class LivekitCallState {
+
+    /** Idle, setting up objects. */
+    object Idle : LivekitCallState()
+
+    /**
+     * CreateOffer. Intermediate state between Idle and Dialing.
+     */
+    object CreateOffer : LivekitCallState()
+
+    /** Dialing.  Outgoing call is signaling the remote peer */
+    object Dialing : LivekitCallState()
+
+    /** Local ringing. Incoming call offer received */
+    object LocalRinging : LivekitCallState()
+
+    /** Answering.  Incoming call is responding to remote peer */
+    object Answering : LivekitCallState()
+
+    /**
+     * Connected. Incoming/Outgoing call
+     * */
+    object Connected : LivekitCallState()
+
+    /** Ended. Incoming/Outgoing call, the call is terminated */
+    data class Ended(val reason: EndCallReason? = null) : LivekitCallState()
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/livekitcall/MxLivekitCall.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/livekitcall/MxLivekitCall.kt
@@ -1,0 +1,64 @@
+package org.matrix.android.sdk.api.session.livekitcall
+
+import org.matrix.android.sdk.api.session.room.model.call.CallCapabilities
+import org.matrix.android.sdk.api.session.room.model.call.EndCallReason
+import org.matrix.android.sdk.api.util.Optional
+
+interface MxLivekitCallDetail {
+    val callId: String
+    val isOutgoing: Boolean
+    val roomId: String
+    val isVideoCall: Boolean
+    val ourPartyId: String
+    val opponentPartyId: Optional<String>?
+    val opponentVersion: Int
+    val opponentUserId: String
+    val capabilities: CallCapabilities?
+}
+
+/**
+ * Define both an incoming call and on outgoing call.
+ */
+interface MxLivekitCall : MxLivekitCallDetail {
+
+    companion object {
+        const val VOIP_PROTO_VERSION = 1
+    }
+
+    var state: LivekitCallState
+
+    /**
+     * Pick Up the incoming call.
+     * It has no effect on outgoing call.
+     */
+    fun accept()
+
+    /**
+     * This has to be sent by the caller's client once it has chosen an answer.
+     */
+    fun selectAnswer()
+
+    /**
+     * Reject an incoming call.
+     */
+    fun reject()
+
+    /**
+     * End the call.
+     */
+    fun hangUp(reason: EndCallReason? = null, duration: Long? = null)
+
+    /**
+     * Start a call.
+     * Send call type (voice, video) to the other participant.
+     */
+    fun inviteParticipantToCall(callType: String)
+
+
+    fun addListener(listener: StateListener)
+    fun removeListener(listener: StateListener)
+
+    interface StateListener {
+        fun onStateUpdate(call: MxLivekitCall)
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/livekitcall/LivekitCallInviteContent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/model/livekitcall/LivekitCallInviteContent.kt
@@ -1,0 +1,51 @@
+package org.matrix.android.sdk.api.session.room.model.livekitcall
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import org.matrix.android.sdk.api.session.room.model.call.CallCapabilities
+import org.matrix.android.sdk.api.session.room.model.call.CallSignalingContent
+
+/**
+ * This event is sent by the caller when they wish to establish a call.
+ */
+@JsonClass(generateAdapter = true)
+data class LivekitCallInviteContent(
+        /**
+         * Required. A unique identifier for the call.
+         */
+        @Json(name = "call_id") override val callId: String?,
+        /**
+         * Required. ID to let user identify remote echo of their own events
+         */
+        @Json(name = "party_id") override val partyId: String? = null,
+        /**
+         * Required. The call type
+         */
+        @Json(name = "type") val type: String?,
+        /**
+         * Required. The version of the VoIP specification this message adheres to.
+         */
+        @Json(name = "version") override val version: String?,
+        /**
+         * Required. The time in milliseconds that the invite is valid for.
+         * Once the invite age exceeds this value, clients should discard it.
+         * They should also no longer show the call as awaiting an answer in the UI.
+         */
+        @Json(name = "lifetime") val lifetime: Int?,
+        /**
+         * The field should be added for all invites where the target is a specific user.
+         */
+        @Json(name = "invitee") val invitee: String? = null,
+        /**
+         * Capability advertisement.
+         */
+        @Json(name = "capabilities") val capabilities: CallCapabilities? = null
+) : CallSignalingContent {
+
+    companion object {
+        const val VIDEO = "video"
+        const val VOICE = "voice"
+    }
+
+    fun isVideo() = type?.contains(VIDEO) == true
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/summary/RoomSummaryConstants.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/api/session/room/summary/RoomSummaryConstants.kt
@@ -30,6 +30,10 @@ object RoomSummaryConstants {
             EventType.CALL_HANGUP,
             EventType.CALL_REJECT,
             EventType.CALL_ANSWER,
+            EventType.GK_CALL_INVITE,
+            EventType.GK_CALL_HANGUP,
+            EventType.GK_CALL_REJECT,
+            EventType.GK_CALL_ANSWER,
             EventType.ENCRYPTED,
             EventType.STICKER,
             EventType.REACTION

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultSession.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultSession.kt
@@ -44,6 +44,7 @@ import org.matrix.android.sdk.api.session.file.FileService
 import org.matrix.android.sdk.api.session.homeserver.HomeServerCapabilitiesService
 import org.matrix.android.sdk.api.session.identity.IdentityService
 import org.matrix.android.sdk.api.session.integrationmanager.IntegrationManagerService
+import org.matrix.android.sdk.api.session.livekitcall.LivekitCallSignalingService
 import org.matrix.android.sdk.api.session.media.MediaService
 import org.matrix.android.sdk.api.session.openid.OpenIdService
 import org.matrix.android.sdk.api.session.permalinks.PermalinkService
@@ -127,6 +128,7 @@ internal class DefaultSession @Inject constructor(
         private val integrationManagerService: Lazy<IntegrationManagerService>,
         private val thirdPartyService: Lazy<ThirdPartyService>,
         private val callSignalingService: Lazy<CallSignalingService>,
+        private val livekitCallSignalingService: Lazy<LivekitCallSignalingService>,
         private val spaceService: Lazy<SpaceService>,
         private val openIdService: Lazy<OpenIdService>,
         private val presenceService: Lazy<PresenceService>,
@@ -228,6 +230,7 @@ internal class DefaultSession @Inject constructor(
     override fun mediaService(): MediaService = mediaService.get()
     override fun integrationManagerService(): IntegrationManagerService = integrationManagerService.get()
     override fun callSignalingService(): CallSignalingService = callSignalingService.get()
+    override fun livekitCallSignalingService(): LivekitCallSignalingService = livekitCallSignalingService.get()
     override fun searchService(): SearchService = searchService.get()
     override fun federationService(): FederationService = federationService.get()
     override fun thirdPartyService(): ThirdPartyService = thirdPartyService.get()

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/SessionComponent.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/SessionComponent.kt
@@ -38,6 +38,7 @@ import org.matrix.android.sdk.internal.session.filter.FilterModule
 import org.matrix.android.sdk.internal.session.homeserver.HomeServerCapabilitiesModule
 import org.matrix.android.sdk.internal.session.identity.IdentityModule
 import org.matrix.android.sdk.internal.session.integrationmanager.IntegrationManagerModule
+import org.matrix.android.sdk.internal.session.livekitcall.LivekitCallModule
 import org.matrix.android.sdk.internal.session.media.MediaModule
 import org.matrix.android.sdk.internal.session.multiroomlocation.MultiRoomModule
 import org.matrix.android.sdk.internal.session.openid.OpenIdModule
@@ -92,6 +93,7 @@ import org.matrix.android.sdk.internal.util.system.SystemModule
             AccountModule::class,
             FederationModule::class,
             CallModule::class,
+            LivekitCallModule::class,
             ContentScannerModule::class,
             SearchModule::class,
             ThirdPartyModule::class,

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/SessionModule.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/SessionModule.kt
@@ -82,6 +82,7 @@ import org.matrix.android.sdk.internal.session.events.DefaultEventService
 import org.matrix.android.sdk.internal.session.homeserver.DefaultHomeServerCapabilitiesService
 import org.matrix.android.sdk.internal.session.identity.DefaultIdentityService
 import org.matrix.android.sdk.internal.session.integrationmanager.IntegrationManager
+import org.matrix.android.sdk.internal.session.livekitcall.LivekitCallEventProcessor
 import org.matrix.android.sdk.internal.session.openid.DefaultOpenIdService
 import org.matrix.android.sdk.internal.session.permalinks.DefaultPermalinkService
 import org.matrix.android.sdk.internal.session.room.EventRelationsAggregationProcessor
@@ -341,6 +342,10 @@ internal abstract class SessionModule {
     @Binds
     @IntoSet
     abstract fun bindCallEventProcessor(processor: CallEventProcessor): EventInsertLiveProcessor
+
+    @Binds
+    @IntoSet
+    abstract fun bindLivekitCallEventProcessor(processor: LivekitCallEventProcessor): EventInsertLiveProcessor
 
     @Binds
     @IntoSet

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/events/DefaultEventService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/events/DefaultEventService.kt
@@ -22,13 +22,13 @@ import org.matrix.android.sdk.internal.database.RealmSessionProvider
 import org.matrix.android.sdk.internal.database.mapper.asDomain
 import org.matrix.android.sdk.internal.database.model.EventEntity
 import org.matrix.android.sdk.internal.database.query.where
-import org.matrix.android.sdk.internal.session.call.CallEventProcessor
+import org.matrix.android.sdk.internal.session.livekitcall.LivekitCallEventProcessor
 import org.matrix.android.sdk.internal.session.room.timeline.GetEventTask
 import javax.inject.Inject
 
 internal class DefaultEventService @Inject constructor(
         private val getEventTask: GetEventTask,
-        private val callEventProcessor: CallEventProcessor,
+        private val callEventProcessor: LivekitCallEventProcessor,
         private val realmSessionProvider: RealmSessionProvider,
 ) : EventService {
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/livekitcall/ActiveLivekitCallHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/livekitcall/ActiveLivekitCallHandler.kt
@@ -1,0 +1,29 @@
+package org.matrix.android.sdk.internal.session.livekitcall
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import org.matrix.android.sdk.api.session.livekitcall.MxLivekitCall
+import org.matrix.android.sdk.internal.session.SessionScope
+import javax.inject.Inject
+
+@SessionScope
+internal class ActiveLivekitCallHandler @Inject constructor() {
+
+    private val activeCallListLiveData: MutableLiveData<MutableList<MxLivekitCall>> by lazy {
+        MutableLiveData<MutableList<MxLivekitCall>>(mutableListOf())
+    }
+
+    fun addCall(call: MxLivekitCall) {
+        activeCallListLiveData.postValue(activeCallListLiveData.value?.apply { add(call) })
+    }
+
+    fun removeCall(callId: String) {
+        activeCallListLiveData.postValue(activeCallListLiveData.value?.apply { removeAll { it.callId == callId } })
+    }
+
+    fun getCallWithId(callId: String): MxLivekitCall? {
+        return activeCallListLiveData.value?.find { it.callId == callId }
+    }
+
+    fun getActiveCallsLiveData(): LiveData<MutableList<MxLivekitCall>> = activeCallListLiveData
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/livekitcall/DefaultLivekitCallSignalingService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/livekitcall/DefaultLivekitCallSignalingService.kt
@@ -1,0 +1,41 @@
+package org.matrix.android.sdk.internal.session.livekitcall
+
+import org.matrix.android.sdk.api.session.livekitcall.LivekitCallListener
+import org.matrix.android.sdk.api.session.livekitcall.LivekitCallSignalingService
+import org.matrix.android.sdk.api.session.livekitcall.MxLivekitCall
+import org.matrix.android.sdk.internal.session.SessionScope
+import javax.inject.Inject
+
+@SessionScope
+internal class DefaultLivekitCallSignalingService @Inject constructor(
+    private val callSignalingHandler: LivekitCallSignalingHandler,
+    private val mxCallFactory: MxLivekitCallFactory,
+    private val activeCallHandler: ActiveLivekitCallHandler,
+) : LivekitCallSignalingService {
+
+    override fun createOutgoingCall(roomId: String, otherUserId: String, isVideoCall: Boolean): MxLivekitCall {
+        return mxCallFactory.createOutgoingCall(roomId, otherUserId, isVideoCall).also {
+            activeCallHandler.addCall(it)
+        }
+    }
+
+    override fun addCallListener(listener: LivekitCallListener) {
+        callSignalingHandler.addCallListener(listener)
+    }
+
+    override fun removeCallListener(listener: LivekitCallListener) {
+        callSignalingHandler.removeCallListener(listener)
+    }
+
+    override fun getCallWithId(callId: String): MxLivekitCall? {
+        return activeCallHandler.getCallWithId(callId)
+    }
+
+    override fun isThereAnyActiveCall(): Boolean {
+        return activeCallHandler.getActiveCallsLiveData().value?.isNotEmpty() == true
+    }
+
+    companion object {
+        const val CALL_TIMEOUT_MS = 120_000
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/livekitcall/LivekitCallEventProcessor.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/livekitcall/LivekitCallEventProcessor.kt
@@ -1,0 +1,66 @@
+package org.matrix.android.sdk.internal.session.livekitcall
+
+import io.realm.Realm
+import org.matrix.android.sdk.api.logger.LoggerTag
+import org.matrix.android.sdk.api.session.events.model.Event
+import org.matrix.android.sdk.api.session.events.model.EventType
+import org.matrix.android.sdk.internal.database.model.EventInsertType
+import org.matrix.android.sdk.internal.session.EventInsertLiveProcessor
+import org.matrix.android.sdk.internal.session.SessionScope
+import timber.log.Timber
+import javax.inject.Inject
+
+private val loggerTag = LoggerTag("LivekitCallEventProcessor", LoggerTag.VOIP)
+
+@SessionScope
+internal class LivekitCallEventProcessor @Inject constructor(private val callSignalingHandler: LivekitCallSignalingHandler) :
+    EventInsertLiveProcessor {
+
+    private val allowedTypes = listOf(
+        EventType.GK_CALL_ANSWER,
+        EventType.GK_CALL_SELECT_ANSWER,
+
+        EventType.CALL_REJECT,
+        EventType.CALL_HANGUP,
+
+        EventType.GK_CALL_REJECT,
+        EventType.GK_CALL_INVITE,
+        EventType.GK_CALL_HANGUP,
+        EventType.ENCRYPTED,
+    )
+
+    private val eventsToPostProcess = mutableListOf<Event>()
+
+    override fun shouldProcess(eventId: String, eventType: String, insertType: EventInsertType): Boolean {
+        if (insertType != EventInsertType.INCREMENTAL_SYNC) {
+            return false
+        }
+        return allowedTypes.contains(eventType)
+    }
+
+    override fun process(realm: Realm, event: Event) {
+        eventsToPostProcess.add(event)
+    }
+
+    fun shouldProcessFastLane(eventType: String): Boolean {
+        return eventType == EventType.GK_CALL_INVITE
+    }
+
+    fun processFastLane(event: Event) {
+        dispatchToCallSignalingHandlerIfNeeded(event)
+    }
+
+    override suspend fun onPostProcess() {
+        eventsToPostProcess.forEach {
+            dispatchToCallSignalingHandlerIfNeeded(it)
+        }
+        eventsToPostProcess.clear()
+    }
+
+    private fun dispatchToCallSignalingHandlerIfNeeded(event: Event) {
+        event.roomId ?: return Unit.also {
+            Timber.tag(loggerTag.value).w("Event with no room id ${event.eventId}")
+        }
+        callSignalingHandler.onCallEvent(event)
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/livekitcall/LivekitCallListenersDispatcher.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/livekitcall/LivekitCallListenersDispatcher.kt
@@ -1,0 +1,58 @@
+package org.matrix.android.sdk.internal.session.livekitcall
+
+import org.matrix.android.sdk.api.extensions.tryOrNull
+import org.matrix.android.sdk.api.session.livekitcall.LivekitCallListener
+import org.matrix.android.sdk.api.session.livekitcall.MxLivekitCall
+import org.matrix.android.sdk.api.session.room.model.call.CallAnswerContent
+import org.matrix.android.sdk.api.session.room.model.call.CallAssertedIdentityContent
+import org.matrix.android.sdk.api.session.room.model.call.CallHangupContent
+import org.matrix.android.sdk.api.session.room.model.call.CallNegotiateContent
+import org.matrix.android.sdk.api.session.room.model.call.CallRejectContent
+import org.matrix.android.sdk.api.session.room.model.call.CallSelectAnswerContent
+import org.matrix.android.sdk.api.session.room.model.livekitcall.LivekitCallInviteContent
+
+/**
+ * Dispatch each method safely to all listeners.
+ */
+internal class LivekitCallListenersDispatcher(private val listeners: Set<LivekitCallListener>) : LivekitCallListener {
+
+    override fun onCallInviteReceived(mxCall: MxLivekitCall, callInviteContent: LivekitCallInviteContent) = dispatch {
+        it.onCallInviteReceived(mxCall, callInviteContent)
+    }
+
+    override fun onCallAnswerReceived(callAnswerContent: CallAnswerContent) = dispatch {
+        it.onCallAnswerReceived(callAnswerContent)
+    }
+
+    override fun onCallHangupReceived(callHangupContent: CallHangupContent) = dispatch {
+        it.onCallHangupReceived(callHangupContent)
+    }
+
+    override fun onCallRejectReceived(callRejectContent: CallRejectContent) = dispatch {
+        it.onCallRejectReceived(callRejectContent)
+    }
+
+    override fun onCallManagedByOtherSession(callId: String) = dispatch {
+        it.onCallManagedByOtherSession(callId)
+    }
+
+    override fun onCallSelectAnswerReceived(callSelectAnswerContent: CallSelectAnswerContent) = dispatch {
+        it.onCallSelectAnswerReceived(callSelectAnswerContent)
+    }
+
+    override fun onCallNegotiateReceived(callNegotiateContent: CallNegotiateContent) = dispatch {
+        it.onCallNegotiateReceived(callNegotiateContent)
+    }
+
+    override fun onCallAssertedIdentityReceived(callAssertedIdentityContent: CallAssertedIdentityContent) = dispatch {
+        it.onCallAssertedIdentityReceived(callAssertedIdentityContent)
+    }
+
+    private fun dispatch(lambda: (LivekitCallListener) -> Unit) {
+        listeners.toList().forEach {
+            tryOrNull {
+                lambda(it)
+            }
+        }
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/livekitcall/LivekitCallModule.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/livekitcall/LivekitCallModule.kt
@@ -1,0 +1,12 @@
+package org.matrix.android.sdk.internal.session.livekitcall
+
+import dagger.Binds
+import dagger.Module
+import org.matrix.android.sdk.api.session.livekitcall.LivekitCallSignalingService
+
+@Module
+internal abstract class LivekitCallModule {
+
+    @Binds
+    abstract fun bindLivekitCallSignalingService(service: DefaultLivekitCallSignalingService): LivekitCallSignalingService
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/livekitcall/LivekitCallSignalingHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/livekitcall/LivekitCallSignalingHandler.kt
@@ -1,0 +1,206 @@
+package org.matrix.android.sdk.internal.session.livekitcall
+
+import org.matrix.android.sdk.api.logger.LoggerTag
+import org.matrix.android.sdk.api.session.events.model.Event
+import org.matrix.android.sdk.api.session.events.model.EventType
+import org.matrix.android.sdk.api.session.events.model.toModel
+import org.matrix.android.sdk.api.session.livekitcall.LivekitCallListener
+import org.matrix.android.sdk.api.session.livekitcall.LivekitCallState
+import org.matrix.android.sdk.api.session.livekitcall.MxLivekitCall
+import org.matrix.android.sdk.api.session.room.model.call.*
+import org.matrix.android.sdk.api.session.room.model.livekitcall.LivekitCallInviteContent
+import org.matrix.android.sdk.internal.di.UserId
+import org.matrix.android.sdk.internal.session.SessionScope
+import org.matrix.android.sdk.internal.util.time.Clock
+import timber.log.Timber
+import javax.inject.Inject
+
+private val loggerTag = LoggerTag("LivekitCallSignalingHandler", LoggerTag.VOIP)
+private const val MAX_AGE_TO_RING = 40_000
+
+@SessionScope
+internal class LivekitCallSignalingHandler @Inject constructor(
+    private val activeCallHandler: ActiveLivekitCallHandler,
+    private val mxCallFactory: MxLivekitCallFactory,
+    @UserId private val userId: String,
+    private val clock: Clock,
+) {
+
+    private val invitedCallIds = mutableSetOf<String>()
+    private val callListeners = mutableSetOf<LivekitCallListener>()
+    private val callListenersDispatcher = LivekitCallListenersDispatcher(callListeners)
+
+    fun addCallListener(listener: LivekitCallListener) {
+        callListeners.add(listener)
+    }
+
+    fun removeCallListener(listener: LivekitCallListener) {
+        callListeners.remove(listener)
+    }
+
+    fun onCallEvent(event: Event) {
+        when (event.getClearType()) {
+            EventType.GK_CALL_ANSWER -> {
+                handleCallAnswerEvent(event)
+            }
+            EventType.GK_CALL_INVITE -> {
+                handleCallInviteEvent(event)
+            }
+            EventType.GK_CALL_HANGUP -> {
+                handleCallHangupEvent(event)
+            }
+            EventType.GK_CALL_REJECT -> {
+                handleCallRejectEvent(event)
+            }
+            EventType.GK_CALL_SELECT_ANSWER -> {
+                handleCallSelectAnswerEvent(event)
+            }
+        }
+    }
+
+    private fun handleCallAssertedIdentityEvent(event: Event) {
+        val content = event.getClearContent().toModel<CallAssertedIdentityContent>() ?: return
+        val call = content.getCall() ?: return
+        if (call.ourPartyId == content.partyId) {
+            // Ignore remote echo (not that we send asserted identity, but still...)
+            return
+        }
+        callListenersDispatcher.onCallAssertedIdentityReceived(content)
+    }
+
+    private fun handleCallNegotiateEvent(event: Event) {
+        val content = event.getClearContent().toModel<CallNegotiateContent>() ?: return
+        val call = content.getCall() ?: return
+        if (call.ourPartyId == content.partyId) {
+            // Ignore remote echo
+            return
+        }
+        callListenersDispatcher.onCallNegotiateReceived(content)
+    }
+
+    private fun handleCallSelectAnswerEvent(event: Event) {
+        val content = event.getClearContent().toModel<CallSelectAnswerContent>() ?: return
+        val call = content.getCall() ?: return
+        if (call.ourPartyId == content.partyId) {
+            // Ignore remote echo
+            return
+        }
+        if (call.isOutgoing) {
+            Timber.tag(loggerTag.value).v("Got selectAnswer for an outbound call: ignoring")
+            return
+        }
+        val selectedPartyId = content.selectedPartyId
+        if (selectedPartyId == null) {
+            Timber.tag(loggerTag.value).w("Got nonsensical select_answer with null selected_party_id: ignoring")
+            return
+        }
+        callListenersDispatcher.onCallSelectAnswerReceived(content)
+    }
+
+    private fun handleCallRejectEvent(event: Event) {
+        val content = event.getClearContent().toModel<CallRejectContent>() ?: return
+        val call = content.getCall() ?: return
+        if (call.ourPartyId == content.partyId) {
+            // Ignore remote echo
+            return
+        }
+        activeCallHandler.removeCall(content.callId)
+        if (event.senderId == userId) {
+            // discard current call, it's rejected by another of my session
+            callListenersDispatcher.onCallManagedByOtherSession(content.callId)
+            return
+        }
+        // No need to check party_id for reject because if we'd received either
+        // an answer or reject, we wouldn't be in state InviteSent
+        if (call.state != LivekitCallState.Dialing) {
+            return
+        }
+        callListenersDispatcher.onCallRejectReceived(content)
+    }
+
+    private fun handleCallHangupEvent(event: Event) {
+        val content = event.getClearContent().toModel<CallHangupContent>() ?: return
+        val call = content.getCall() ?: return
+        // party ID must match (our chosen partner hanging up the call) or be undefined (we haven't chosen
+        // a partner yet but we're treating the hangup as a reject as per VoIP v0)
+        if (call.opponentPartyId != null && !call.partyIdsMatches(content)) {
+            Timber.tag(loggerTag.value).v("Ignoring hangup from party ID ${content.partyId} we have chosen party ID ${call.opponentPartyId}")
+            return
+        }
+        if (call.state !is LivekitCallState.Ended) {
+            activeCallHandler.removeCall(content.callId)
+            callListenersDispatcher.onCallHangupReceived(content)
+        }
+    }
+
+    private fun handleCallInviteEvent(event: Event) {
+        if (event.senderId == userId) {
+            // ignore invites you send
+            return
+        }
+        if (event.roomId == null || event.senderId == null) {
+            return
+        }
+        val now = clock.epochMillis()
+        val age = now - (event.ageLocalTs ?: now)
+        if (age > MAX_AGE_TO_RING) {
+            Timber.tag(loggerTag.value).w("Call invite is too old to ring.")
+            return
+        }
+        val content = event.getClearContent().toModel<LivekitCallInviteContent>() ?: return
+
+        content.callId ?: return
+        if (invitedCallIds.contains(content.callId)) {
+            // Call is already known, maybe due to fast lane. Ignore
+            Timber.tag(loggerTag.value).d("Ignoring already known call invite")
+            return
+        }
+        val incomingCall = mxCallFactory.createIncomingCall(
+                roomId = event.roomId,
+                opponentUserId = event.senderId,
+                content = content
+        ) ?: return
+        invitedCallIds.add(content.callId)
+        activeCallHandler.addCall(incomingCall)
+        callListenersDispatcher.onCallInviteReceived(incomingCall, content)
+    }
+
+    private fun handleCallAnswerEvent(event: Event) {
+        val content = event.getClearContent().toModel<CallAnswerContent>() ?: return
+        val call = content.getCall() ?: return
+        if (call.ourPartyId == content.partyId) {
+            // Ignore remote echo
+            return
+        }
+        if (event.roomId == null || event.senderId == null) {
+            return
+        }
+        if (event.senderId == userId) {
+            // discard current call, it's answered by another of my session
+            activeCallHandler.removeCall(call.callId)
+            callListenersDispatcher.onCallManagedByOtherSession(content.callId)
+        } else {
+            if (call.opponentPartyId != null) {
+                Timber.tag(loggerTag.value)
+                        .v("Ignoring answer from party ID ${content.partyId} we already have an answer from ${call.opponentPartyId}")
+                return
+            }
+            mxCallFactory.updateOutgoingCallWithOpponentData(call, event.senderId, content, content.capabilities)
+            callListenersDispatcher.onCallAnswerReceived(content)
+        }
+    }
+
+    private fun MxLivekitCall.partyIdsMatches(contentSignalingContent: CallSignalingContent): Boolean {
+        return opponentPartyId?.getOrNull() == contentSignalingContent.partyId
+    }
+
+    private fun CallSignalingContent.getCall(): MxLivekitCall? {
+        val currentCall = callId?.let {
+            activeCallHandler.getCallWithId(it)
+        }
+        if (currentCall == null) {
+            Timber.tag(loggerTag.value).v("Call with id $callId is null")
+        }
+        return currentCall
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/livekitcall/MxLivekitCallFactory.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/livekitcall/MxLivekitCallFactory.kt
@@ -1,0 +1,71 @@
+package org.matrix.android.sdk.internal.session.livekitcall
+
+import org.matrix.android.sdk.api.MatrixConfiguration
+import org.matrix.android.sdk.api.session.call.CallIdGenerator
+import org.matrix.android.sdk.api.session.livekitcall.MxLivekitCall
+import org.matrix.android.sdk.api.session.room.model.call.CallCapabilities
+import org.matrix.android.sdk.api.session.room.model.call.CallSignalingContent
+import org.matrix.android.sdk.api.session.room.model.livekitcall.LivekitCallInviteContent
+import org.matrix.android.sdk.internal.di.DeviceId
+import org.matrix.android.sdk.internal.di.UserId
+import org.matrix.android.sdk.internal.session.livekitcall.model.MxLivekitCallImpl
+import org.matrix.android.sdk.internal.session.profile.GetProfileInfoTask
+import org.matrix.android.sdk.internal.session.room.send.LocalEchoEventFactory
+import org.matrix.android.sdk.internal.session.room.send.queue.EventSenderProcessor
+import org.matrix.android.sdk.internal.util.time.Clock
+import javax.inject.Inject
+
+internal class MxLivekitCallFactory @Inject constructor(
+        @DeviceId private val deviceId: String?,
+        private val localEchoEventFactory: LocalEchoEventFactory,
+        private val eventSenderProcessor: EventSenderProcessor,
+        private val matrixConfiguration: MatrixConfiguration,
+        @UserId private val userId: String,
+        private val clock: Clock,
+) {
+
+    fun createIncomingCall(roomId: String, opponentUserId: String, content: LivekitCallInviteContent): MxLivekitCall? {
+        content.callId ?: return null
+        return MxLivekitCallImpl(
+            callId = content.callId,
+            isOutgoing = false,
+            roomId = roomId,
+            userId = userId,
+            ourPartyId = deviceId ?: "",
+            isVideoCall = content.isVideo(),
+            localEchoEventFactory = localEchoEventFactory,
+            eventSenderProcessor = eventSenderProcessor,
+            matrixConfiguration = matrixConfiguration,
+            clock = clock,
+        ).apply {
+            updateOpponentData(opponentUserId, content, content.capabilities)
+        }
+    }
+
+    fun createOutgoingCall(roomId: String, opponentUserId: String, isVideoCall: Boolean): MxLivekitCall {
+        return MxLivekitCallImpl(
+                callId = CallIdGenerator.generate(),
+                isOutgoing = true,
+                roomId = roomId,
+                userId = userId,
+                ourPartyId = deviceId ?: "",
+                isVideoCall = isVideoCall,
+                localEchoEventFactory = localEchoEventFactory,
+                eventSenderProcessor = eventSenderProcessor,
+                matrixConfiguration = matrixConfiguration,
+                clock = clock,
+        ).apply {
+            // Setup with this userId, might be updated when processing the Answer event
+            this.opponentUserId = opponentUserId
+        }
+    }
+
+    fun updateOutgoingCallWithOpponentData(
+            call: MxLivekitCall,
+            userId: String,
+            content: CallSignalingContent,
+            callCapabilities: CallCapabilities?
+    ) {
+        (call as? MxLivekitCallImpl)?.updateOpponentData(userId, content, callCapabilities)
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/livekitcall/model/MxLivekitCallImpl.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/livekitcall/model/MxLivekitCallImpl.kt
@@ -1,0 +1,179 @@
+package org.matrix.android.sdk.internal.session.livekitcall.model
+
+import org.matrix.android.sdk.api.MatrixConfiguration
+import org.matrix.android.sdk.api.logger.LoggerTag
+import org.matrix.android.sdk.api.session.call.MxCall
+import org.matrix.android.sdk.api.session.events.model.*
+import org.matrix.android.sdk.api.session.room.model.call.*
+import org.matrix.android.sdk.api.session.room.model.livekitcall.LivekitCallInviteContent
+import org.matrix.android.sdk.api.util.Optional
+import org.matrix.android.sdk.internal.session.livekitcall.DefaultLivekitCallSignalingService
+import org.matrix.android.sdk.api.session.livekitcall.LivekitCallState
+import org.matrix.android.sdk.api.session.livekitcall.MxLivekitCall
+import org.matrix.android.sdk.internal.session.room.send.LocalEchoEventFactory
+import org.matrix.android.sdk.internal.session.room.send.queue.EventSenderProcessor
+import org.matrix.android.sdk.internal.util.time.Clock
+import timber.log.Timber
+import java.math.BigDecimal
+
+private val loggerTag = LoggerTag("MxLivekitCallImpl", LoggerTag.VOIP)
+
+internal class MxLivekitCallImpl(
+    override val callId: String,
+    override val isOutgoing: Boolean,
+    override val roomId: String,
+    private val userId: String,
+    override val isVideoCall: Boolean,
+    override val ourPartyId: String,
+    private val localEchoEventFactory: LocalEchoEventFactory,
+    private val eventSenderProcessor: EventSenderProcessor,
+    private val matrixConfiguration: MatrixConfiguration,
+    private val clock: Clock,
+) : MxLivekitCall {
+
+    override var opponentPartyId: Optional<String>? = null
+    override var opponentVersion: Int = MxCall.VOIP_PROTO_VERSION
+    override lateinit var opponentUserId: String
+    override var capabilities: CallCapabilities? = null
+
+    fun updateOpponentData(userId: String, content: CallSignalingContent, callCapabilities: CallCapabilities?) {
+        opponentPartyId = Optional.from(content.partyId)
+        opponentVersion = content.version?.let { BigDecimal(it).intValueExact() } ?: MxLivekitCall.VOIP_PROTO_VERSION
+        opponentUserId = userId
+        capabilities = callCapabilities ?: CallCapabilities()
+    }
+
+    override var state: LivekitCallState = LivekitCallState.Idle
+        set(value) {
+            field = value
+            dispatchStateChange()
+        }
+
+    private val listeners = mutableListOf<MxLivekitCall.StateListener>()
+
+    override fun addListener(listener: MxLivekitCall.StateListener) {
+        listeners.add(listener)
+    }
+
+    override fun removeListener(listener: MxLivekitCall.StateListener) {
+        listeners.remove(listener)
+    }
+
+    private fun dispatchStateChange() {
+        listeners.forEach {
+            try {
+                it.onStateUpdate(this)
+            } catch (failure: Throwable) {
+                Timber.tag(loggerTag.value).d("dispatchStateChange failed for call $callId : ${failure.localizedMessage}")
+            }
+        }
+    }
+
+    init {
+        state = if (isOutgoing) {
+            LivekitCallState.Idle
+        } else {
+            // because it's created on reception of an offer
+            LivekitCallState.LocalRinging
+        }
+    }
+
+    override fun inviteParticipantToCall(callType: String) {
+        if (!isOutgoing) return
+        Timber.tag(loggerTag.value).v("offerSdp $callId")
+        state = LivekitCallState.Dialing
+        LivekitCallInviteContent(
+            callId = callId,
+            partyId = ourPartyId,
+            lifetime = DefaultLivekitCallSignalingService.CALL_TIMEOUT_MS,
+            type = callType,
+            version = MxCall.VOIP_PROTO_VERSION.toString()
+        )
+                .let { createEventAndLocalEcho(type = EventType.GK_CALL_INVITE, roomId = roomId, content = it.toContent()) }
+                .also { eventSenderProcessor.postEvent(it) }
+    }
+
+    override fun reject() {
+        if (opponentVersion < 1) {
+            Timber.tag(loggerTag.value).v("Opponent version is less than 1 ($opponentVersion): sending hangup instead of reject")
+            hangUp(EndCallReason.USER_HANGUP)
+            return
+        }
+        Timber.tag(loggerTag.value).v("reject $callId")
+        CallRejectContent(
+            callId = callId,
+            partyId = ourPartyId,
+            version = MxCall.VOIP_PROTO_VERSION.toString()
+        )
+                .let { createEventAndLocalEcho(type = EventType.GK_CALL_REJECT, roomId = roomId, content = it.toContent()) }
+                .also { eventSenderProcessor.postEvent(it) }
+        state = LivekitCallState.Ended(reason = EndCallReason.USER_HANGUP)
+    }
+
+    override fun hangUp(reason: EndCallReason?, duration: Long?) {
+        Timber.tag(loggerTag.value).v("hangup $callId")
+        CallHangupContent(
+            callId = callId,
+            partyId = ourPartyId,
+            reason = reason,
+            duration = duration,
+            version = MxCall.VOIP_PROTO_VERSION.toString()
+        )
+                .let { createEventAndLocalEcho(type = EventType.GK_CALL_HANGUP, roomId = roomId, content = it.toContent()) }
+                .also { eventSenderProcessor.postEvent(it) }
+        state = LivekitCallState.Ended(reason)
+    }
+
+    override fun accept() {
+        Timber.tag(loggerTag.value).v("accept $callId")
+        if (isOutgoing) return
+        state = LivekitCallState.Answering
+        CallAnswerContent(
+            callId = callId,
+            partyId = ourPartyId,
+            answer = CallAnswerContent.Answer(sdp = ""),
+            version = MxCall.VOIP_PROTO_VERSION.toString(),
+            capabilities = buildCapabilities()
+        )
+                .let { createEventAndLocalEcho(type = EventType.GK_CALL_ANSWER, roomId = roomId, content = it.toContent()) }
+                .also { eventSenderProcessor.postEvent(it) }
+    }
+
+    override fun selectAnswer() {
+        Timber.tag(loggerTag.value).v("select answer $callId")
+        if (!isOutgoing) return
+        // This is an outgoing call, select the remote client that answered.
+        if (state != LivekitCallState.Dialing && state !is LivekitCallState.Connected) {
+            Timber.tag(loggerTag.value).w("Expected state is CallState.Dialing or CallState.Connected got $state.")
+        }
+        CallSelectAnswerContent(
+            callId = callId,
+            partyId = ourPartyId,
+            selectedPartyId = opponentPartyId?.getOrNull(),
+            version = MxCall.VOIP_PROTO_VERSION.toString()
+        )
+                .let { createEventAndLocalEcho(type = EventType.GK_CALL_SELECT_ANSWER, roomId = roomId, content = it.toContent()) }
+                .also { eventSenderProcessor.postEvent(it) }
+    }
+
+    private fun createEventAndLocalEcho(localId: String = LocalEcho.createLocalEchoId(), type: String, roomId: String, content: Content): Event {
+        return Event(
+            roomId = roomId,
+            originServerTs = clock.epochMillis(),
+            senderId = userId,
+            eventId = localId,
+            type = type,
+            content = content,
+            unsignedData = UnsignedData(age = null, transactionId = localId)
+        )
+                .also { localEchoEventFactory.createLocalEcho(it) }
+    }
+
+    private fun buildCapabilities(): CallCapabilities? {
+        return if (matrixConfiguration.supportsCallTransfer) {
+            CallCapabilities(true)
+        } else {
+            null
+        }
+    }
+}

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/job/SyncThread.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/job/SyncThread.kt
@@ -35,11 +35,11 @@ import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.failure.Failure
 import org.matrix.android.sdk.api.failure.isTokenError
 import org.matrix.android.sdk.api.logger.LoggerTag
-import org.matrix.android.sdk.api.session.call.MxCall
+import org.matrix.android.sdk.api.session.livekitcall.MxLivekitCall
 import org.matrix.android.sdk.api.session.sync.SyncState
 import org.matrix.android.sdk.api.session.sync.model.SyncResponse
 import org.matrix.android.sdk.internal.network.NetworkConnectivityChecker
-import org.matrix.android.sdk.internal.session.call.ActiveCallHandler
+import org.matrix.android.sdk.internal.session.livekitcall.ActiveLivekitCallHandler
 import org.matrix.android.sdk.internal.session.sync.SyncTask
 import org.matrix.android.sdk.internal.settings.DefaultLightweightSettingsStorage
 import org.matrix.android.sdk.internal.util.BackgroundDetectionObserver
@@ -60,7 +60,7 @@ internal class SyncThread @Inject constructor(
         private val syncTask: SyncTask,
         private val networkConnectivityChecker: NetworkConnectivityChecker,
         private val backgroundDetectionObserver: BackgroundDetectionObserver,
-        private val activeCallHandler: ActiveCallHandler,
+        private val activeCallHandler: ActiveLivekitCallHandler,
         private val lightweightSettingsStorage: DefaultLightweightSettingsStorage,
         private val matrixConfiguration: MatrixConfiguration,
 ) : Thread("Matrix-SyncThread"), NetworkConnectivityChecker.Listener, BackgroundDetectionObserver.Listener {
@@ -77,7 +77,7 @@ internal class SyncThread @Inject constructor(
     private var retryNoNetworkTask: TimerTask? = null
     private var previousSyncResponseHasToDevice = false
 
-    private val activeCallListObserver = Observer<MutableList<MxCall>> { activeCalls ->
+    private val activeCallListObserver = Observer<MutableList<MxLivekitCall>> { activeCalls ->
         if (activeCalls.isEmpty() && backgroundDetectionObserver.isInBackground) {
             pause()
         }


### PR DESCRIPTION
Unfortunately, it seems impossible to achieve the complete separation of livekit service from matrix call.

I had to do some substitution for DefaultEventService, SyncThread. These processor and handler do the same things but for our event types. Also, the update supports backward compatibility, so the prev event types of calls will be visible in timeline